### PR TITLE
fix deadlink to unidic official page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # unidic-py
 
-This is a version of [UniDic](https://unidic.ninjal.ac.jp/) packaged for use
+This is a version of [UniDic](https://ccd.ninjal.ac.jp/unidic/) packaged for use
 with pip. 
 
 Currently it supports 2.3.0, the latest version of UniDic. **Note this will
@@ -39,7 +39,7 @@ See the `extras` directory for details on how to replicate the build process.
 # License
 
 The modern Japanese UniDic is available under the GPL, LGPL, or BSD license,
-[see here](https://unidic.ninjal.ac.jp/download#unidic_bccwj). UniDic is
+[see here](https://ccd.ninjal.ac.jp/unidic/download#unidic_bccwj). UniDic is
 developed by [NINJAL](https://www.ninjal.ac.jp/), the National Institute for
 Japanese Language and Linguistics. UniDic is copyrighted by the UniDic
 Consortium and is distributed here under the terms of the [BSD

--- a/doc/dataset.md
+++ b/doc/dataset.md
@@ -73,7 +73,7 @@ by MeCab.
 UniDic fields are defined at [NINJAL's UniDic FAQ page][faq]. unidic-lite uses
 a subset of the fields in the most recent version.
 
-[faq]: https://unidic.ninjal.ac.jp/faq
+[faq]: https://ccd.ninjal.ac.jp/unidic/faq
 
 IPADic fields are as follows:
 
@@ -90,7 +90,7 @@ IPADic fields are as follows:
 
 UniDic is developed by NINJAL. Here are some resources on UniDic:
 
-- [UniDic home page](https://unidic.ninjal.ac.jp/faq)
+- [UniDic home page](https://ccd.ninjal.ac.jp/unidic/faq)
 - [Universal Dependencies for Japanese](https://www.semanticscholar.org/paper/Universal-Dependencies-for-Japanese-Tanaka-Miyao/064b601542d27471e397f8df811f0ddb54824113)
 
 The MeCab documentation covers dictionary formats and tokenizer options. It

--- a/extras/README.md
+++ b/extras/README.md
@@ -3,7 +3,7 @@
 unidic-py distributes a slightly modified version of UniDic for ease of use. To
 build this dictionary yourself, perform the following steps:
 
-1. Download the official latest UniDic from the [homepage](https://unidic.ninjal.ac.jp/)
+1. Download the official latest UniDic from the [homepage](https://ccd.ninjal.ac.jp/unidic/)
 2. Use `clean-lex.sh` to rewrite `lex.csv`
 3. Copy the appropriate `reiwa.csv` to your dictionary directory (the number is the field count)
 4. Run the normal mecab dictionary build command


### PR DESCRIPTION
The links to UniDic pages ( https://unidic.ninjal.ac.jp/ ) is now dead.

![unidic.ninjal.ac.jp](https://user-images.githubusercontent.com/1157344/139537514-cd37c6f8-ca5b-4cc4-8e8f-1c64eb2963f4.png)

it looks that it moved to https://ccd.ninjal.ac.jp/unidic/

![ccd.ninjal.ac.jp/unidic](https://user-images.githubusercontent.com/1157344/139537539-8bc1f639-821e-43e3-8701-6a8a28d79537.png)

> UniDic ウェブページを
> 旧ページ (https://unidic.ninjal.ac.jp/)から
> 本ページ (https://ccd.ninjal.ac.jp/unidic/) に移設しました。