### PR TITLE
Custom URL parameter for "python -m unidic download"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ following command:
 
     python -m unidic download
 
+Additionally you can specify custom version and URL arguments demonstrated as such:
+
+    python -m unidic download "3.1.0+2021-08-31" "https://cotonoha-dic.s3-ap-northeast-1.amazonaws.com/unidic-3.1.0.zip"
+
 With [fugashi](https://github.com/polm/fugashi) or
 [mecab-python3](https://github.com/samurait/mecab-python3) unidic will be used
 automatically when installed, though if you want you can manually pass the

--- a/unidic/download.py
+++ b/unidic/download.py
@@ -89,17 +89,26 @@ def download_and_clean(version, url, dirname='unidic', delfiles=[]):
 
 DICT_INFO = "https://raw.githubusercontent.com/polm/unidic-py/master/dicts.json"
 
-def download_version(ver="latest"):
-    res = get_json(DICT_INFO, "dictionary info")
-    try:
-        dictinfo = res[ver]
-    except KeyError:
-        print('Unknown version "{}".'.format(ver))
-        print("Known versions:")
-        for key, val in res.items():
-            print("\t", key, "({})".format(val['version']))
-
-    print("download url:", dictinfo['url'])
-    print("Dictionary version:", dictinfo['version'])
-    download_and_clean(dictinfo['version'], dictinfo['url'])
+def download_version(ver="latest", url:str=""):
+    if len(url) > 0:
+        print('Custom download params: url="{}"; ver="{}".'.format(url, ver))
+        try:
+            res = get_json(DICT_INFO, "dictionary info")
+            dictinfo = res[ver]
+            ver = dictinfo['version']
+        finally:
+            download_and_clean(ver, url)
+    else:
+        res = get_json(DICT_INFO, "dictionary info")
+        try:
+            dictinfo = res[ver]
+        except KeyError:
+            print('Unknown version "{}".'.format(ver))
+            print("Known versions:")
+            for key, val in res.items():
+                print("\t", key, "({})".format(val['version']))
+    
+        print("download url:", dictinfo['url'])
+        print("Dictionary version:", dictinfo['version'])
+        download_and_clean(dictinfo['version'], dictinfo['url'])
 


### PR DESCRIPTION
The following command is an example of how to use this change:

>python -m unidic download "3.1.0+2021-08-31" "https://cotonoha-dic.s3-ap-northeast-1.amazonaws.com/unidic-3.1.0.zip"

I made two changes to the codebase:
1. The unidic download command can now accept a URL argument due to a small change in the "download_version" function code. The original behavior is unaffected.
2. The README.md documentation has been updated to explain how to specify custom "ver" and "url" parameters with an example.
